### PR TITLE
Add comprehensive scraper for thecovenant.es content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.npmrc
+.DS_Store

--- a/data/.gitignore
+++ b/data/.gitignore
@@ -1,0 +1,3 @@
+# Ignore scraper outputs by default
+*.json
+!README.md

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,650 @@
+{
+  "name": "thecovenant-tools",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "thecovenant-tools",
+      "version": "0.1.0",
+      "dependencies": {
+        "axios": "^1.7.7",
+        "cheerio": "^1.0.0-rc.12",
+        "fast-xml-parser": "^4.4.2",
+        "p-limit": "^4.0.0"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
+      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.4",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "license": "ISC"
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/cheerio": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.1.2.tgz",
+      "integrity": "sha512-IkxPpb5rS/d1IiLbHMgfPuS0FgiWTtFIm/Nj+2woXDLTZ7fOT2eqzgYbdMlLweqlHbsZjxEChoVK+7iph7jyQg==",
+      "license": "MIT",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "encoding-sniffer": "^0.2.1",
+        "htmlparser2": "^10.0.0",
+        "parse5": "^7.3.0",
+        "parse5-htmlparser2-tree-adapter": "^7.1.0",
+        "parse5-parser-stream": "^7.1.2",
+        "undici": "^7.12.0",
+        "whatwg-mimetype": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.1"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/cheerio-select": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-select": "^5.1.0",
+        "css-what": "^6.1.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/encoding-sniffer": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
+      "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "whatwg-encoding": "^3.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.3.tgz",
+      "integrity": "sha512-RKihhV+SHsIUGXObeVy9AXiBbFwkVk7Syp8XgwN5U3JV416+Gwp/GO9i0JYKmikykgz/UHRrrV4ROuZEo/T0ig==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "strnum": "^1.1.1"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.0.0.tgz",
+      "integrity": "sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.1",
+        "entities": "^6.0.0"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
+      "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
+      "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-parser-stream": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/strnum": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.1.2.tgz",
+      "integrity": "sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.16.0.tgz",
+      "integrity": "sha512-QEg3HPMll0o3t2ourKwOeUAZ159Kn9mx5pnzHRQO8+Wixmh88YdZRiIwat0iNzNNXn0yoEtXJqFpyW7eM8BV7g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.1.tgz",
+      "integrity": "sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "thecovenant-tools",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "scrape": "node scripts/scrape-thecovenant.mjs"
+  },
+  "dependencies": {
+    "axios": "^1.7.7",
+    "cheerio": "^1.0.0-rc.12",
+    "fast-xml-parser": "^4.4.2",
+    "p-limit": "^4.0.0"
+  }
+}

--- a/scripts/scrape-thecovenant.mjs
+++ b/scripts/scrape-thecovenant.mjs
@@ -1,0 +1,605 @@
+import fs from 'fs/promises';
+import path from 'path';
+import axios from 'axios';
+import * as cheerio from 'cheerio';
+import { XMLParser } from 'fast-xml-parser';
+import pLimit from 'p-limit';
+
+const DEFAULT_START_URL = process.env.SCRAPE_START_URL || 'https://www.thecovenant.es/';
+const OUTPUT_FILE = process.env.SCRAPE_OUTPUT || path.resolve(process.cwd(), 'data', 'thecovenant-export.json');
+const MAX_PAGES = Number.parseInt(process.env.SCRAPE_MAX_PAGES || '', 10) || 2000;
+const CONCURRENCY = Number.parseInt(process.env.SCRAPE_CONCURRENCY || '', 10) || 5;
+const REQUEST_TIMEOUT = Number.parseInt(process.env.SCRAPE_TIMEOUT || '', 10) || 20000;
+const INCLUDE_SITEMAPS = (process.env.SCRAPE_INCLUDE_SITEMAPS || 'true').toLowerCase() !== 'false';
+
+const axiosClient = axios.create({
+  timeout: REQUEST_TIMEOUT,
+  headers: {
+    'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36',
+    'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+    'Accept-Language': 'es-ES,es;q=0.9,en;q=0.8'
+  },
+  responseType: 'text',
+  maxRedirects: 5,
+  validateStatus: status => status >= 200 && status < 400
+});
+
+function createAllowedHostnames(startUrl) {
+  const url = new URL(startUrl);
+  const hostnames = new Set([url.hostname]);
+  if (url.hostname.startsWith('www.')) {
+    hostnames.add(url.hostname.slice(4));
+  } else {
+    hostnames.add(`www.${url.hostname}`);
+  }
+  return hostnames;
+}
+
+const allowedHostnames = createAllowedHostnames(DEFAULT_START_URL);
+
+const visited = new Set();
+const enqueued = new Set();
+const crawlResults = [];
+
+const limit = pLimit(CONCURRENCY);
+
+function normalizeUrl(rawUrl, baseUrl) {
+  if (!rawUrl) return null;
+  try {
+    const resolved = new URL(rawUrl, baseUrl);
+    if (!['http:', 'https:'].includes(resolved.protocol)) {
+      return null;
+    }
+    if (!allowedHostnames.has(resolved.hostname)) {
+      return null;
+    }
+    resolved.hash = '';
+    const searchParams = Array.from(resolved.searchParams.keys()).sort();
+    const normalizedSearch = new URLSearchParams();
+    for (const key of searchParams) {
+      for (const value of resolved.searchParams.getAll(key)) {
+        if (value !== undefined && value !== null) {
+          normalizedSearch.append(key, value);
+        }
+      }
+    }
+    const normalizedQuery = normalizedSearch.toString();
+    resolved.search = normalizedQuery ? `?${normalizedQuery}` : '';
+    if (resolved.pathname !== '/' && resolved.pathname.endsWith('/')) {
+      resolved.pathname = resolved.pathname.replace(/\/+/g, '/').replace(/\/$/, '');
+    }
+    return resolved.toString();
+  } catch (error) {
+    return null;
+  }
+}
+
+function toAbsoluteUrl(rawUrl, baseUrl) {
+  if (!rawUrl) return null;
+  try {
+    const resolved = new URL(rawUrl, baseUrl);
+    resolved.hash = '';
+    return resolved.toString();
+  } catch (error) {
+    return null;
+  }
+}
+
+function extractMetaTags($) {
+  const meta = [];
+  $('meta').each((_, element) => {
+    const attribs = element.attribs || {};
+    meta.push({
+      name: attribs.name || null,
+      property: attribs.property || null,
+      content: attribs.content || null,
+      charset: attribs.charset || null,
+      httpEquiv: attribs['http-equiv'] || null
+    });
+  });
+  return meta;
+}
+
+function extractLinkTags($, pageUrl) {
+  const links = [];
+  $('a[href]').each((_, element) => {
+    const attribs = element.attribs || {};
+    const rawHref = attribs.href;
+    const absoluteHref = toAbsoluteUrl(rawHref, pageUrl);
+    let normalizedHref = null;
+    let internal = false;
+    if (absoluteHref) {
+      const parsed = new URL(absoluteHref);
+      internal = allowedHostnames.has(parsed.hostname);
+      if (internal) {
+        normalizedHref = normalizeUrl(absoluteHref, pageUrl);
+      }
+    }
+    const $element = $(element);
+    links.push({
+      text: $element.text().replace(/\s+/g, ' ').trim() || null,
+      html: $element.html() || null,
+      href: absoluteHref,
+      title: attribs.title || null,
+      rel: attribs.rel || null,
+      target: attribs.target || null,
+      internal,
+      normalizedHref
+    });
+  });
+  return links;
+}
+
+function extractImages($, pageUrl) {
+  const images = [];
+  $('img[src]').each((_, element) => {
+    const attribs = element.attribs || {};
+    const absoluteSrc = toAbsoluteUrl(attribs.src, pageUrl);
+    images.push({
+      src: absoluteSrc,
+      srcset: attribs.srcset || null,
+      dataSrc: attribs['data-src'] || null,
+      alt: attribs.alt || null,
+      title: attribs.title || null,
+      width: attribs.width || null,
+      height: attribs.height || null,
+      loading: attribs.loading || null
+    });
+  });
+  return images;
+}
+
+function extractMedia($, pageUrl) {
+  const media = { videos: [], audio: [], iframes: [] };
+  $('video').each((_, element) => {
+    const attribs = element.attribs || {};
+    const sources = [];
+    const $element = $(element);
+    $element.find('source[src]').each((_, source) => {
+      const $source = $(source);
+      sources.push({
+        src: toAbsoluteUrl($source.attr('src'), pageUrl),
+        type: $source.attr('type') || null
+      });
+    });
+    media.videos.push({
+      poster: toAbsoluteUrl(attribs.poster, pageUrl),
+      controls: attribs.controls !== undefined,
+      autoplay: attribs.autoplay !== undefined,
+      loop: attribs.loop !== undefined,
+      muted: attribs.muted !== undefined,
+      sources
+    });
+  });
+  $('audio').each((_, element) => {
+    const attribs = element.attribs || {};
+    const sources = [];
+    const $element = $(element);
+    $element.find('source[src]').each((_, source) => {
+      const $source = $(source);
+      sources.push({
+        src: toAbsoluteUrl($source.attr('src'), pageUrl),
+        type: $source.attr('type') || null
+      });
+    });
+    media.audio.push({
+      controls: attribs.controls !== undefined,
+      autoplay: attribs.autoplay !== undefined,
+      loop: attribs.loop !== undefined,
+      muted: attribs.muted !== undefined,
+      sources
+    });
+  });
+  $('iframe[src]').each((_, element) => {
+    const attribs = element.attribs || {};
+    media.iframes.push({
+      src: toAbsoluteUrl(attribs.src, pageUrl),
+      title: attribs.title || null,
+      allow: attribs.allow || null,
+      width: attribs.width || null,
+      height: attribs.height || null,
+      loading: attribs.loading || null
+    });
+  });
+  return media;
+}
+
+function extractJsonLd($) {
+  const scripts = [];
+  $('script[type="application/ld+json"]').each((_, element) => {
+    const $element = $(element);
+    const jsonText = $element.html()?.trim();
+    if (!jsonText) return;
+    try {
+      const data = JSON.parse(jsonText);
+      scripts.push(data);
+    } catch (error) {
+      scripts.push({ error: 'Invalid JSON-LD', raw: jsonText });
+    }
+  });
+  return scripts;
+}
+
+function extractOutline($, rootSelector) {
+  const headings = [];
+  const root = rootSelector ? $(rootSelector) : $('body');
+  root.find('h1, h2, h3, h4, h5, h6').each((_, element) => {
+    const tagName = element.tagName?.toLowerCase();
+    if (!tagName) return;
+    const level = Number.parseInt(tagName.replace('h', ''), 10);
+    const $element = $(element);
+    headings.push({
+      level,
+      text: $element.text().replace(/\s+/g, ' ').trim(),
+      id: element.attribs?.id || null,
+      html: $element.html()
+    });
+  });
+  const outline = [];
+  const stack = [];
+  for (const heading of headings) {
+    const node = { ...heading, children: [] };
+    while (stack.length && stack[stack.length - 1].level >= node.level) {
+      stack.pop();
+    }
+    if (stack.length === 0) {
+      outline.push(node);
+    } else {
+      stack[stack.length - 1].children.push(node);
+    }
+    stack.push(node);
+  }
+  return outline;
+}
+
+function extractContentBlocks($, pageUrl) {
+  const root = $('article').first().length ? $('article').first() : $('main').first().length ? $('main').first() : $('body');
+  const blocks = [];
+  const selector = 'h1, h2, h3, h4, h5, h6, p, blockquote, pre, code, ul, ol, figure, table';
+  root.find(selector).each((_, element) => {
+    const tagName = element.tagName?.toLowerCase();
+    if (!tagName) return;
+    const $element = $(element);
+    const text = $element.text().replace(/\s+/g, ' ').trim();
+    const block = {
+      tag: tagName,
+      text: text || null,
+      html: $element.html() || null
+    };
+    if (tagName === 'ul' || tagName === 'ol') {
+      block.items = $element.find('> li').map((_, li) => $(li).text().replace(/\s+/g, ' ').trim()).get();
+    }
+    if (tagName === 'figure') {
+      block.caption = $element.find('figcaption').text().trim() || null;
+      const img = $element.find('img').first();
+      if (img.length) {
+        block.image = {
+          src: toAbsoluteUrl(img.attr('src'), pageUrl),
+          alt: img.attr('alt') || null,
+          title: img.attr('title') || null
+        };
+      }
+    }
+    if (tagName === 'table') {
+      const rows = [];
+      $element.find('tr').each((_, row) => {
+        const $row = $(row);
+        rows.push($row.find('th, td').map((_, cell) => $(cell).text().replace(/\s+/g, ' ').trim()).get());
+      });
+      block.rows = rows;
+    }
+    blocks.push(block);
+  });
+  return blocks;
+}
+
+function extractSections($) {
+  const sections = [];
+  $('section').each((_, element) => {
+    const attribs = element.attribs || {};
+    const $element = $(element);
+    sections.push({
+      id: attribs.id || null,
+      className: attribs.class || null,
+      html: $element.html(),
+      text: $element.text().replace(/\s+/g, ' ').trim() || null
+    });
+  });
+  return sections;
+}
+
+function extractFeeds($, pageUrl) {
+  const feeds = [];
+  $('link[rel="alternate"]').each((_, element) => {
+    const attribs = element.attribs || {};
+    const type = attribs.type || '';
+    if (type.includes('xml') || type.includes('rss') || type.includes('atom') || type.includes('json')) {
+      feeds.push({
+        type,
+        title: attribs.title || null,
+        href: toAbsoluteUrl(attribs.href, pageUrl)
+      });
+    }
+  });
+  return feeds;
+}
+
+async function fetchPage(url) {
+  try {
+    const response = await axiosClient.get(url);
+    return { success: true, status: response.status, data: response.data, headers: response.headers };
+  } catch (error) {
+    if (error.response) {
+      return { success: false, status: error.response.status, data: error.response.data, headers: error.response.headers };
+    }
+    return { success: false, status: null, error: error.message };
+  }
+}
+
+async function processUrl(url) {
+  if (visited.has(url)) {
+    return;
+  }
+  visited.add(url);
+  console.log(`Crawling: ${url}`);
+  const pageResult = await fetchPage(url);
+  if (!pageResult.success) {
+    crawlResults.push({
+      url,
+      status: pageResult.status,
+      error: pageResult.error || `Failed to fetch resource (${pageResult.status})`,
+      fetchedAt: new Date().toISOString(),
+      contentType: pageResult.headers?.['content-type'] || null,
+      rawHtml: typeof pageResult.data === 'string' ? pageResult.data : null
+    });
+    return;
+  }
+  const html = pageResult.data;
+  const $ = cheerio.load(html, { decodeEntities: false });
+  const pageInfo = {
+    url,
+    status: pageResult.status,
+    fetchedAt: new Date().toISOString(),
+    contentType: pageResult.headers?.['content-type'] || null,
+    contentLength: pageResult.headers?.['content-length'] || null,
+    title: $('title').first().text().trim() || null,
+    language: $('html').attr('lang') || null,
+    metaDescription: $('meta[name="description"]').attr('content') || null,
+    canonicalUrl: toAbsoluteUrl($('link[rel="canonical"]').attr('href'), url),
+    meta: extractMetaTags($),
+    feeds: extractFeeds($, url),
+    links: extractLinkTags($, url),
+    images: extractImages($, url),
+    media: extractMedia($, url),
+    outline: extractOutline($),
+    sections: extractSections($),
+    contentBlocks: extractContentBlocks($, url),
+    textContent: $('body').text().replace(/\s+/g, ' ').trim() || null,
+    jsonLd: extractJsonLd($),
+    stylesheets: $('link[rel="stylesheet"]').map((_, el) => toAbsoluteUrl(el.attribs?.href, url)).get(),
+    inlineStyles: $('style').map((_, el) => ($(el).html() || '').trim()).get(),
+    scripts: $('script[src]').map((_, el) => toAbsoluteUrl(el.attribs?.src, url)).get(),
+    inlineScripts: $('script:not([src])').map((_, el) => ($(el).html() || '').trim()).get(),
+    rawHtml: html
+  };
+
+  crawlResults.push(pageInfo);
+
+  const discoveredLinks = new Set();
+  for (const link of pageInfo.links) {
+    if (link.internal && link.normalizedHref) {
+      discoveredLinks.add(link.normalizedHref);
+    }
+  }
+
+  for (const nextUrl of discoveredLinks) {
+    enqueue(nextUrl);
+  }
+}
+
+async function parseSitemap(sitemapUrl) {
+  try {
+    const response = await axiosClient.get(sitemapUrl);
+    const parser = new XMLParser({ ignoreAttributes: false, allowBooleanAttributes: true });
+    const data = parser.parse(response.data);
+    const urls = new Set();
+
+    function extractUrls(node) {
+      if (!node) return;
+      if (Array.isArray(node)) {
+        node.forEach(extractUrls);
+        return;
+      }
+      if (node.loc) {
+        if (typeof node.loc === 'string') {
+          const normalized = normalizeUrl(node.loc, sitemapUrl);
+          if (normalized) {
+            urls.add(normalized);
+          }
+        } else if (Array.isArray(node.loc)) {
+          node.loc.forEach(value => {
+            const normalized = normalizeUrl(value, sitemapUrl);
+            if (normalized) {
+              urls.add(normalized);
+            }
+          });
+        }
+      }
+      if (node.url) {
+        extractUrls(node.url);
+      }
+      if (node.sitemap) {
+        const sitemapNodes = Array.isArray(node.sitemap) ? node.sitemap : [node.sitemap];
+        for (const sitemapNode of sitemapNodes) {
+          if (sitemapNode.loc) {
+            const nestedUrl = Array.isArray(sitemapNode.loc) ? sitemapNode.loc[0] : sitemapNode.loc;
+            const normalized = normalizeUrl(nestedUrl, sitemapUrl);
+            if (normalized) {
+              urls.add(normalized);
+            }
+          }
+        }
+      }
+      for (const value of Object.values(node)) {
+        if (typeof value === 'object') {
+          extractUrls(value);
+        }
+      }
+    }
+
+    extractUrls(data);
+    return urls;
+  } catch (error) {
+    console.warn(`Unable to parse sitemap ${sitemapUrl}: ${error.message}`);
+    return new Set();
+  }
+}
+
+async function discoverSeedUrls(startUrl) {
+  const start = new URL(startUrl);
+  const normalizedStart = normalizeUrl(startUrl, startUrl);
+  const pageSeeds = new Set();
+  if (normalizedStart) {
+    pageSeeds.add(normalizedStart);
+  }
+  if (!INCLUDE_SITEMAPS) {
+    return { pageSeeds: Array.from(pageSeeds), sitemapSeeds: [] };
+  }
+  const sitemapSeeds = new Set();
+  const robotsUrl = `${start.origin}/robots.txt`;
+  try {
+    const response = await axiosClient.get(robotsUrl);
+    const lines = response.data.split(/\r?\n/);
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (trimmed.toLowerCase().startsWith('sitemap:')) {
+        const sitemapUrl = trimmed.slice('sitemap:'.length).trim();
+        const absolute = toAbsoluteUrl(sitemapUrl, robotsUrl);
+        if (absolute) {
+          sitemapSeeds.add(absolute);
+        }
+      }
+    }
+  } catch (error) {
+    console.warn(`Unable to fetch robots.txt (${robotsUrl}): ${error.message}`);
+  }
+
+  sitemapSeeds.add(`${start.origin}/sitemap.xml`);
+  sitemapSeeds.add(`${start.origin}/sitemap_index.xml`);
+
+  return {
+    pageSeeds: Array.from(pageSeeds),
+    sitemapSeeds: Array.from(sitemapSeeds)
+  };
+}
+
+async function hydrateSitemap(sitemapUrl, visitedSitemaps) {
+  const absolute = toAbsoluteUrl(sitemapUrl, DEFAULT_START_URL);
+  if (!absolute) {
+    return;
+  }
+  const canonical = normalizeUrl(absolute, DEFAULT_START_URL) || absolute;
+  if (!allowedHostnames.has(new URL(canonical).hostname)) {
+    return;
+  }
+  if (visitedSitemaps.has(canonical)) {
+    return;
+  }
+  visitedSitemaps.add(canonical);
+  const urls = await parseSitemap(canonical);
+  for (const url of urls) {
+    if (url.endsWith('.xml')) {
+      await hydrateSitemap(url, visitedSitemaps);
+    } else {
+      enqueue(url);
+    }
+  }
+}
+
+function enqueue(url) {
+  if (!url) return;
+  if (visited.has(url) || enqueued.has(url)) {
+    return;
+  }
+  if (crawlResults.length + enqueued.size >= MAX_PAGES) {
+    return;
+  }
+  enqueued.add(url);
+  queue.push(url);
+  scheduleNext();
+}
+
+const queue = [];
+let activeCount = 0;
+let resolveIdle = null;
+const idlePromise = new Promise(resolve => {
+  resolveIdle = resolve;
+});
+
+function scheduleNext() {
+  if (queue.length === 0 && activeCount === 0) {
+    resolveIdle?.();
+    return;
+  }
+  while (activeCount < CONCURRENCY && queue.length > 0) {
+    const nextUrl = queue.shift();
+    if (!nextUrl) {
+      continue;
+    }
+    activeCount += 1;
+    limit(() => processUrl(nextUrl)).catch(error => {
+      console.error(`Error processing ${nextUrl}:`, error.message);
+    }).finally(() => {
+      enqueued.delete(nextUrl);
+      activeCount -= 1;
+      scheduleNext();
+    });
+  }
+}
+
+async function run() {
+  console.log('Descubriendo URLs iniciales...');
+  const { pageSeeds, sitemapSeeds } = await discoverSeedUrls(DEFAULT_START_URL);
+  if (pageSeeds.length === 0) {
+    enqueue(DEFAULT_START_URL);
+  } else {
+    for (const seed of pageSeeds) {
+      enqueue(seed);
+    }
+  }
+  if (INCLUDE_SITEMAPS) {
+    const visitedSitemaps = new Set();
+    for (const sitemapUrl of sitemapSeeds) {
+      const normalized = toAbsoluteUrl(sitemapUrl, DEFAULT_START_URL);
+      if (normalized && allowedHostnames.has(new URL(normalized).hostname)) {
+        await hydrateSitemap(normalized, visitedSitemaps);
+      }
+    }
+  }
+  if (queue.length === 0) {
+    enqueue(DEFAULT_START_URL);
+  }
+  await idlePromise;
+
+  const exportData = {
+    crawledAt: new Date().toISOString(),
+    startUrl: DEFAULT_START_URL,
+    totalPages: crawlResults.length,
+    settings: {
+      maxPages: MAX_PAGES,
+      concurrency: CONCURRENCY,
+      includeSitemaps: INCLUDE_SITEMAPS
+    },
+    pages: crawlResults
+  };
+
+  const outputDir = path.dirname(OUTPUT_FILE);
+  await fs.mkdir(outputDir, { recursive: true });
+  await fs.writeFile(OUTPUT_FILE, JSON.stringify(exportData, null, 2), 'utf8');
+  console.log(`Export completado. ${crawlResults.length} páginas guardadas en ${OUTPUT_FILE}`);
+}
+
+run().catch(error => {
+  console.error('El proceso de scraping falló:', error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- add a Node.js scraper that crawls thecovenant.es recursively, capturing metadata, structured content, media, and links into a consolidated JSON export
- configure project tooling with package metadata, dependencies, and an npm script for running the scraper
- ignore generated datasets and local dependencies to keep the repository clean

## Testing
- SCRAPE_MAX_PAGES=1 npm run scrape

------
https://chatgpt.com/codex/tasks/task_b_68e23bb5393083338390f89947800286